### PR TITLE
restore confirm class

### DIFF
--- a/Resources/public/js/confirm.js
+++ b/Resources/public/js/confirm.js
@@ -25,6 +25,8 @@ function smartConfirm(e,referer,type){
     },
     function(data){
       $("body").append(data);
+      $(referer).addClass('confirm');
+      $(referer).removeClass('confirm-waiting');
     }
   );
 


### PR DESCRIPTION
confirm button once clicked, stays inactive forever

this is not acceptable when there is an list with checkboxes that can select items to delete

so i propose to restore confirm class to referer after modal box has been showed
