### PR TITLE
make the handler agnostic of twig to avoid circular reference

### DIFF
--- a/EventListener/AlertifyListener.php
+++ b/EventListener/AlertifyListener.php
@@ -32,6 +32,7 @@ class AlertifyListener implements EventSubscriberInterface
      * @var Session
      */
     private $session;
+    private $twig;
 
     /**
      * AlertifyListener constructor.
@@ -39,10 +40,11 @@ class AlertifyListener implements EventSubscriberInterface
      * @param Session                $session
      * @param AlertifySessionHandler $alertifySessionHandler
      */
-    public function __construct(Session $session, AlertifySessionHandler $alertifySessionHandler)
+    public function __construct(\Twig_Environment $twig, Session $session, AlertifySessionHandler $alertifySessionHandler)
     {
-        $this->alertifySessionHandler = $alertifySessionHandler;
+        $this->twig = $twig;
         $this->session = $session;
+        $this->alertifySessionHandler = $alertifySessionHandler;
     }
 
     public function onKernelResponse(FilterResponseEvent $event)
@@ -69,7 +71,7 @@ class AlertifyListener implements EventSubscriberInterface
         $isRedirectResponse = $response instanceof RedirectResponse;
 
         if ($hasBody && !$hasMetaRefresh && !$isRedirectResponse) {
-            $alertify = $this->alertifySessionHandler->handle($this->session);
+            $alertify = $this->alertifySessionHandler->handle($this->session, $this->twig);
             $content = substr($content, 0, $endBodyPos).$alertify.substr($content, $endBodyPos);
             $response->setContent($content);
         }

--- a/Handler/AlertifySessionHandler.php
+++ b/Handler/AlertifySessionHandler.php
@@ -25,9 +25,8 @@ class AlertifySessionHandler
      * @param \Twig_Environment $twig
      * @param array             $defaultParameters
      */
-    public function __construct(\Twig_Environment $twig, array $defaultParameters)
+    public function __construct(array $defaultParameters)
     {
-        $this->twig = $twig;
         $this->defaultParameters = $defaultParameters;
     }
 
@@ -39,7 +38,7 @@ class AlertifySessionHandler
      *
      * @return string
      */
-    public function handle($session)
+    public function handle($session, \Twig_Environment $twig)
     {
         $flashes = $session->getFlashBag()->all();
 
@@ -56,7 +55,7 @@ class AlertifySessionHandler
                 }
 
                 $parameters['type'] = $type;
-                $renders[$type.$key] = $this->twig->render('TroopersAlertifyBundle::'.$parameters['engine'].'.html.twig', $parameters);
+                $renders[$type.$key] = $twig->render('TroopersAlertifyBundle::'.$parameters['engine'].'.html.twig', $parameters);
             }
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,11 +15,11 @@
             <argument type="service" id="session" />
         </service>
         <service id="troopers_alertifybundle.session_handler" class="%alertify.handler.session.class%">
-            <argument type="service" id="twig" />
             <argument>%troopers_alertify%</argument>
         </service>
         <service id="troopers_alertifybundle.event_listener" class="%alertify.event_listener%">
             <tag name="kernel.event_subscriber" />
+            <argument type="service" id="twig" />
             <argument type="service" id="session" />
             <argument type="service" id="troopers_alertifybundle.session_handler" />
         </service>

--- a/Tests/Handler/AlertifySessionHandlerTest.php
+++ b/Tests/Handler/AlertifySessionHandlerTest.php
@@ -29,16 +29,16 @@ class AlertifySessionHandlerTest extends \PHPUnit\Framework\TestCase
         /** @var AlertifyHelper $helper */
         $helper = new AlertifyHelper($this->session);
         $handler = new AlertifySessionHandler(
-            $this->getTwigEnvironmentMock(),
             $container->getParameter('troopers_alertify')
         );
+        $twig = $this->getTwigEnvironmentMock();
 
         $helper->congrat('Alert1');
-        $this->assertEquals(1, count(explode(' ', $handler->handle($this->session))));
+        $this->assertEquals(1, count(explode(' ', $handler->handle($this->session, $twig))));
         $helper->congrat('Alert2');
         $helper->congrat('Alert3', ['opt1' => 42]);
         $helper->congrat('Alert4');
-        $this->assertEquals(3, count(explode(' ', $handler->handle($this->session))));
+        $this->assertEquals(3, count(explode(' ', $handler->handle($this->session, $twig))));
     }
 
     /**
@@ -52,6 +52,7 @@ class AlertifySessionHandlerTest extends \PHPUnit\Framework\TestCase
     protected function getTwigEnvironmentMock()
     {
         $twigEnvironment = $this->getMockBuilder('Twig_Environment')
+            ->disableOriginalConstructor()
             ->setMethods(['render'])
             ->getMock();
 

--- a/Twig/Extension/AlertifyExtension.php
+++ b/Twig/Extension/AlertifyExtension.php
@@ -61,6 +61,6 @@ class AlertifyExtension extends \Twig_Extension implements \Twig_Extension_InitR
      */
     public function alertifyFilter($environment, Session $session)
     {
-        return $this->alertifySessionHandler->handle($session);
+        return $this->alertifySessionHandler->handle($session, $environment);
     }
 }


### PR DESCRIPTION
This circular occurs in non-identified occasions, particulary with the [victoire](https://github.com/victoire/victoire) project.