### PR TITLE
handle new X-Inject-Alertify header in AlertifyListener

### DIFF
--- a/Exception/IncompatibleStatusCodeException.php
+++ b/Exception/IncompatibleStatusCodeException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Troopers\AlertifyBundle\Exception;
+
+/**
+ * Class IncompatibleStatusCodeException.
+ */
+class IncompatibleStatusCodeException extends \Exception
+{
+    /**
+     * IncompatibleStatusCodeException constructor.
+     *
+     * @param string $message
+     * @param int    $code
+     * @param null   $previous
+     */
+    public function __construct($message = "Status code 204 can't have content, please choose another one.", $code = 544, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ With Alertify, give the final user a unique and harmnized view f your notificati
 - [Installation](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/installation.md)
 - [Configuration](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/configuration.md)
 - [Getting started](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/getting_started.md)
-- [Advanced (modal, confirmation modal)](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/advanced.md)
+- [Advanced (modal, confirmation modal, custom header)](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/advanced.md)
 - [Pro tips](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/pro_tips.md)

--- a/Resources/doc/advanced.md
+++ b/Resources/doc/advanced.md
@@ -71,3 +71,15 @@ Instead of that, the js we'll be ran.
 ```html
     <a href="/your_url" class="btn btn-mini btn-danger" data-toggle="confirm" data-title="Are you sure ?" data-body="Kittens will suffer ! Do you confirm ?" data-cancel-button-class="cancel" data-confirm-button-class="danger">Burn some cats</a>
 ```
+
+## Custom header
+
+If you want to force the trigger of an alert, after an ajax call for example, you need to send through the response a custom header : `X-Inject-Alertify`.  When its value is set to `true`, then the alert append at the end of the response content, even if it is empty. Note that the `204` status code (No content) is incompatible with this header, as the 204 response MUST NOT include a message-body.
+
+## Example :
+
+```php
+return new Response(null, 200, [
+	'X-Inject-Alertify' => true
+]);
+```


### PR DESCRIPTION
Handle new header : 'X-Inject-Alertify'. When sent to the Response with 'true' value, then the alert is forced to be consumed. Note that the status code sent through the Response must be different from 204 (No Content), or an IncompatibleStatusCodeException is thrown.