### PR TITLE
Allow Symfony 5 and fix compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ php:
     - 7.4
 
 install: COMPOSER_MEMORY_LIMIT=-1 composer update
-script: vendor/bin/phpunit -v
+script: vendor/bin/simple-phpunit -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 
 php:
     - 7.0
+    - 7.4
 
 install: COMPOSER_MEMORY_LIMIT=-1 composer update
 script: vendor/bin/phpunit -v

--- a/Controller/AlertifyController.php
+++ b/Controller/AlertifyController.php
@@ -17,6 +17,7 @@ class AlertifyController extends AbstractController
      *
      * @param Request $request An HTTP request.
      * @Route("/confirm", name="alertify_confirm", options={"expose"=true})
+     *
      * @return Response
      */
     public function confirmAction(Request $request)
@@ -45,6 +46,7 @@ class AlertifyController extends AbstractController
      *
      * @param Request $request An HTTP request.
      * @Route("/ajax", name="alertify_ajax", options={"expose"=true})
+     *
      * @return Response
      */
     public function ajaxAction(Request $request)

--- a/Controller/AlertifyController.php
+++ b/Controller/AlertifyController.php
@@ -45,7 +45,6 @@ class AlertifyController extends AbstractController
      *
      * @param Request $request An HTTP request.
      * @Route("/ajax", name="alertify_ajax", options={"expose"=true})
-     *
      * @return Response
      */
     public function ajaxAction(Request $request)

--- a/Controller/AlertifyController.php
+++ b/Controller/AlertifyController.php
@@ -3,23 +3,21 @@
 namespace Troopers\AlertifyBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Alertify controller.
  */
-class AlertifyController extends Controller
+class AlertifyController extends AbstractController
 {
     /**
      * Confirm modal.
      *
      * @param Request $request An HTTP request.
      * @Route("/confirm", name="alertify_confirm", options={"expose"=true})
-     * @Template("TroopersAlertifyBundle::confirm.html.twig")
-     *
-     * @return array
+     * @return Response
      */
     public function confirmAction(Request $request)
     {
@@ -28,7 +26,7 @@ class AlertifyController extends Controller
             $confirmCallback = null;
         }
 
-        return [
+        return $this->render('@TroopersAlertify/confirm.html.twig', [
             'title'                => $request->get('title'),
             'body'                 => $request->get('body'),
             'id'                   => $request->get('id').rand(1, 100).'-modal',
@@ -39,7 +37,7 @@ class AlertifyController extends Controller
             'modal_class'          => $request->get('modal_class'),
             'type'                 => $request->get('type'),
             'confirmCallback'      => $confirmCallback,
-        ];
+        ]);
     }
 
     /**
@@ -47,9 +45,8 @@ class AlertifyController extends Controller
      *
      * @param Request $request An HTTP request.
      * @Route("/ajax", name="alertify_ajax", options={"expose"=true})
-     * @Template("TroopersAlertifyBundle::ajax.html.twig")
      *
-     * @return array
+     * @return Response
      */
     public function ajaxAction(Request $request)
     {
@@ -66,6 +63,6 @@ class AlertifyController extends Controller
             $this->get('session')->getFlashBag()->add($request->get('main_type'), $options);
         }
 
-        return [];
+        return $this->render('@TroopersAlertify/ajax.html.twig');
     }
 }

--- a/Controller/AlertifyControllerTrait.php
+++ b/Controller/AlertifyControllerTrait.php
@@ -5,7 +5,7 @@ namespace Troopers\AlertifyBundle\Controller;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
- * @property Container container
+ * @property Container $container
  */
 trait AlertifyControllerTrait
 {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('troopers_alertify');
+        $treeBuilder = new TreeBuilder('troopers_alertify', 'array');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('troopers_alertify', 'array');
+        }
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/EventListener/AlertifyListener.php
+++ b/EventListener/AlertifyListener.php
@@ -17,8 +17,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Troopers\AlertifyBundle\Exception\IncompatibleStatusCodeException;
 use Troopers\AlertifyBundle\Handler\AlertifySessionHandler;
+use Twig\Environment;
 
 /**
  * AlertifyListener append the alertify views to the response.
@@ -40,14 +43,17 @@ class AlertifyListener implements EventSubscriberInterface
      * @param Session                $session
      * @param AlertifySessionHandler $alertifySessionHandler
      */
-    public function __construct(\Twig_Environment $twig, Session $session, AlertifySessionHandler $alertifySessionHandler)
+    public function __construct(Environment $twig, Session $session, AlertifySessionHandler $alertifySessionHandler)
     {
         $this->twig = $twig;
         $this->session = $session;
         $this->alertifySessionHandler = $alertifySessionHandler;
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    /**
+     * @param ResponseEvent|FilterResponseEvent $event
+     */
+    public function onKernelResponse($event)
     {
         $response = $event->getResponse();
         $request = $event->getRequest();

--- a/Handler/AlertifySessionHandler.php
+++ b/Handler/AlertifySessionHandler.php
@@ -3,6 +3,7 @@
 namespace Troopers\AlertifyBundle\Handler;
 
 use Symfony\Component\HttpFoundation\Session\Session;
+use Twig\Environment;
 
 /**
  * AlertifySessionHandler.
@@ -10,7 +11,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 class AlertifySessionHandler
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $twig;
 
@@ -22,8 +23,8 @@ class AlertifySessionHandler
     /**
      * AlertifySessionHandler constructor.
      *
-     * @param \Twig_Environment $twig
-     * @param array             $defaultParameters
+     * @param Environment $twig
+     * @param array       $defaultParameters
      */
     public function __construct(array $defaultParameters)
     {
@@ -31,14 +32,14 @@ class AlertifySessionHandler
     }
 
     /**
-     * Alertify .
+     * Alertify.
      *
-     * @param \Twig_Environment $this-twig
-     * @param Session           $session
+     * @param Environment $twig
+     * @param Session     $session
      *
      * @return string
      */
-    public function handle($session, \Twig_Environment $twig)
+    public function handle($session, Environment $twig)
     {
         $flashes = $session->getFlashBag()->all();
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,9 +11,10 @@
     </parameters>
 
     <services>
-        <service id="alertify" class="%alertify.helper.class%">
+        <service id="alertify" class="%alertify.helper.class%" public="true">
             <argument type="service" id="session" />
         </service>
+        <service id="%alertify.helper.class%" alias="alertify" />
         <service id="troopers_alertifybundle.session_handler" class="%alertify.handler.session.class%">
             <argument>%troopers_alertify%</argument>
         </service>

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -32,10 +32,74 @@ troopers_alertify:
     ...
 ```
 
-Assetic injections
+Assets injections
 ------------------
 
+First, don't forget that the most of the available libraries here need jquery so you'll need to include it first.
 To add libraries in your views, two ways are possible :
+
+#### Classic way (recommended) (need `composer req symfony/asset`)
+
+This is how embed libraries in your views without AsseticInjectorBundle :
+
+- For **Toastr** :
+```twig
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/toastr/css/toastr.css') }}" type="text/css" />
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('/bundles/troopersalertify/toastr/js/toastr.js') }}"></script>
+{% endblock %}
+```
+
+- For **PushJs** :
+```twig
+{% block javascripts %}
+    <script src="{{ asset('/bundles/troopersalertify/push.js/push.min.js') }}"></script>
+{% endblock %}
+```
+
+- For **noty** :
+```twig
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/noty/css/jquery.noty.css') }}" type="text/css" />
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('/bundles/troopersalertify/noty/js/jquery.noty.js') }}"></script>
+{% endblock %}
+```
+
+- For **notie** :
+```twig
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/notie/notie.css') }}" type="text/css" />
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('/bundles/troopersalertify/notie/notie.js') }}"></script>
+{% endblock %}
+
+```
+
+- For **Codrops notification**
+```twig
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/codrops-notification/css/ns-default.css') }}" type="text/css" />
+    //and according to the choosed theme :
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/codrops-notification/css/ns-style-bar.css') }}" type="text/css" />
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/codrops-notification/css/ns-style-attached.css') }}" type="text/css" />
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/codrops-notification/css/ns-style-growl.css') }}" type="text/css" />
+    <link rel="stylesheet" href="{{ asset('/bundles/troopersalertify/codrops-notification/css/ns-style-other.cs') }}" type="text/css" />
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('/bundles/troopersalertify/codrops-notification/js/classie.js') }}"></script>
+    <script src="{{ asset('/bundles/troopersalertify/codrops-notification/js/modernizr.custom.js') }}"></script>
+    <script src="{{ asset('/bundles/troopersalertify/codrops-notification/js/notificationFx.js') }}"></script>
+{% endblock %}
+```
 
 #### Use [AsseticInjectorBundle](https://github.com/Troopers/AsseticInjectorBundle)
 
@@ -66,87 +130,3 @@ This is the list of available injections :
 - `alertify-codrops-notification`
 - `alertify-pushjs` - *only for javascripts injection*
 - `foot` : Add confirm.js and alertify.js - *only for javascripts injection*
-
-#### Add the library yourself
-
-This is how embed libraries in your views without AsseticInjectorBundle :
-
-- For **Toastr** :
-```twig
-{% stylesheets
-    '@TroopersAlertifyBundle/Resources/public/toastr/css/toastr.css'
-%}
-    <link rel="stylesheet" href="{{ asset_url }}" type="text/css" />
-{% endstylesheets %}
-
-{% javascripts
-    '@TroopersAlertifyBundle/Resources/public/toastr/js/toastr.js'
-%}
-    <script src="{{ asset_url }}"></script>
-{% endjavascripts %}
-
-```
-
-- For **PushJs** :
-```twig
-{% javascripts
-    '@TroopersAlertifyBundle/Resources/public/push.js/push.min.js'
-%}
-    <script src="{{ asset_url }}"></script>
-{% endjavascripts %}
-
-```
-
-- For **noty** :
-```twig
-{% stylesheets
-    '@TroopersAlertifyBundle/Resources/public/noty/css/jquery.noty.css'
-%}
-    <link rel="stylesheet" href="{{ asset_url }}" type="text/css" />
-{% endstylesheets %}
-
-{% javascripts
-    '@TroopersAlertifyBundle/Resources/public/noty/js/jquery.noty.js'
-%}
-    <script src="{{ asset_url }}"></script>
-{% endjavascripts %}
-
-```
-
-- For **notie** :
-```twig
-{% stylesheets
-    '@TroopersAlertifyBundle/Resources/public/notie/notie.css'
-%}
-    <link rel="stylesheet" href="{{ asset_url }}" type="text/css" />
-{% endstylesheets %}
-
-{% javascripts
-    '@TroopersAlertifyBundle/Resources/public/notie/notie.js'
-%}
-    <script src="{{ asset_url }}"></script>
-{% endjavascripts %}
-
-```
-
-- For **Codrops notification**
-```twig
-{% stylesheets
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/css/ns-default.css",
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/css/ns-style-bar.css",
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/css/ns-style-attached.css",
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/css/ns-style-growl.css",
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/css/ns-style-other.css"
-%}
-    <link rel="stylesheet" href="{{ asset_url }}" type="text/css" />
-{% endstylesheets %}
-
-{% javascripts
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/js/classie.js",
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/js/modernizr.custom.js",
-    "@TroopersAlertifyBundle/Resources/public/codrops-notification/js/notificationFx.js"
-%}
-    <script src="{{ asset_url }}"></script>
-{% endjavascripts %}
-```
-

--- a/Resources/doc/getting_started.md
+++ b/Resources/doc/getting_started.md
@@ -2,16 +2,54 @@
 
 ## Adding message
 
-```
+### In your controller
+
+#### Classic way :
+
+```php
     $this->get('session')->getFlashBag()->add('success', 'ok');
     $this->get('session')->getFlashBag()->add('warning', array('body' => 'ok', 'context' => 'front', 'options' => ['option1' => 'custom value']);
 ```
 
+#### Using the autowire and the helper :
+
+```php
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+use use Troopers\AlertifyBundle\Helper\AlertifyHelper;
+
+class GrumpyGnomeController extends AbstractController
+{
+    /**
+     * @Route("/grumpy/gnome", name="grumpy_gnome")
+     */
+    public function index(AlertifyHelper $alertify)
+    {
+        $alertify->congrat('Congratulation !');
+        $alertify->scold('WTF are you kidding !');
+        $alertify->inform('Did you know ?');
+        $alertify->warn('Come on, be careful kid !');
+
+        return $this->render('grumpy_gnome/index.html.twig');
+    }
+}
+```
+
 ## Rendering alert message
 
-### Automatically on the `kernel.response` event
+### This is automatically done on the `kernel.response` event
 
-### In ajax or for another use, you can use either the `alertify` twig filter
+The flash messages are handled in the `kernel.response` thanks to the `Troopers/AlertifyBundle/EventListener/AlertifyListener` class.
+
+If it doesn't display messages, you need to check 2 things :
+- do you have a previous session ? If not, you'll have to create one first or force the injection. You have two way to do this, adding the alertify filter (read below) or adding the `'X-Inject-Alertify' => true` header to your response [Advanced](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/advanced.md)
+- are the assets correctly loaded ? [Configuration](https://github.com/Troopers/TroopersAlertifyBundle/blob/master/Resources/doc/configuration.md)
+
+### To force flash display (ajax, no session mode...), you can use either the `alertify` twig filter in your templates :
 
 ```twig
     {{ app.session|alertify|raw }}

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -14,11 +14,15 @@ Add it in your AppKernel.php (pass to next step with Flex 💪):
             new Troopers\AlertifyBundle\TroopersAlertifyBundle(),
 ```
 
-Warning: make sure the twig engine is turned on in framework.yaml
+Warning: make sure the twig engine is installed and turned on in framework.yaml
+If not :
 
-  - If not, add the following to `config/packages/framework.yaml` (or `config/config.yml` for symfony <4 versions):
+- runs `composer req twig`
+- if needed, add the following to `config/packages/framework.yaml` (or `config/config.yml` for symfony <4 versions)
 
+```yaml
 framework:
     # ...
     templating:
         engines: ['twig']
+```

--- a/Resources/views/notie.html.twig
+++ b/Resources/views/notie.html.twig
@@ -3,7 +3,7 @@
     $(document).ready(function(){
         notie.setOptions({
         {% for key, value in options %}
-            {% spaceless %}
+            {% apply spaceless %}
                 {# if value is boolean, integer or float, do not wrap with quote #}
                 {% if value != true or value != false or value matches '/^\\d+$/' or value matches '/^[-+]?[0-9]*\\.?[0-9]+$/' %}
                     {% set wrapper = false %}
@@ -11,7 +11,7 @@
                 {% set wrapper = true %}
                 {{ key }}: {% if wrapper %}"{% endif %}{{ value }}{% if wrapper %}"{% endif %}
                 {% if not loop.last %},{% endif %}
-            {% endspaceless %}
+            {% endapply %}
         {% endfor %}
         });
         

--- a/Tests/Controller/AlertifyControllerTest.php
+++ b/Tests/Controller/AlertifyControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Troopers\AlertifyBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class AlertifyControllerTest extends WebTestCase
+{
+    public function testConfirm()
+    {
+        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
+
+        $client = static::createClient();
+
+        $client->request('GET', '/alertify/confirm');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testAjax()
+    {
+        $_SERVER['KERNEL_CLASS'] = TestKernel::class;
+
+        $client = static::createClient();
+
+        $client->request('GET', '/alertify/ajax');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+}
+
+

--- a/Tests/Controller/AlertifyControllerTest.php
+++ b/Tests/Controller/AlertifyControllerTest.php
@@ -28,5 +28,3 @@ class AlertifyControllerTest extends WebTestCase
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 }
-
-

--- a/Tests/Controller/TestKernel.php
+++ b/Tests/Controller/TestKernel.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Troopers\AlertifyBundle\Tests\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Troopers\AlertifyBundle\TroopersAlertifyBundle;
+
+class TestKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = [
+            new FrameworkBundle(),
+            new SensioFrameworkExtraBundle(),
+            new TwigBundle(),
+            new TroopersAlertifyBundle(),
+        ];
+
+        return $bundles;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config.yml');
+    }
+}

--- a/Tests/Controller/config.yml
+++ b/Tests/Controller/config.yml
@@ -1,0 +1,18 @@
+framework:
+    secret: 'azertyuiop'
+    test: true
+    session:
+        storage_id: session.storage.mock_file
+    router:
+        resource: '%kernel.project_dir%/Resources/config/routing.yml'
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+    Troopers\AlertifyBundle\Controller\AlertifyController:
+        public: true
+        tags: ['controller.service_arguments']
+
+sensio_framework_extra:
+    router:      { annotations: true } # Deprecated; use routing annotations of Symfony core instead

--- a/Tests/Controller/routing.yml
+++ b/Tests/Controller/routing.yml
@@ -1,0 +1,2 @@
+troopers_alertify:
+    resource: "@TroopersAlertifyBundle/Resources/config/routing.yml"

--- a/Tests/DependencyInjection/AlertifyExtensionTest.php
+++ b/Tests/DependencyInjection/AlertifyExtensionTest.php
@@ -30,7 +30,7 @@ class AlertifyExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('front', $container->getParameter('troopers_alertify.default.context'));
         $this->assertEquals('toastr', $container->getParameter('troopers_alertify.default.engine'));
         $this->assertEquals(null, $container->getParameter('troopers_alertify.default.layout'));
-        $this->assertEquals('alertify', $container->getParameter('troopers_alertify.default.translationdomain'));
+        $this->assertEquals('alertify', $container->getParameter('troopers_alertify.default.translationDomain'));
     }
 
     public function testContexts()
@@ -101,6 +101,6 @@ class AlertifyExtensionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('front', $container->getParameter('troopers_alertify.default.context'));
         $this->assertEquals('notie', $container->getParameter('troopers_alertify.default.engine'));
         $this->assertEquals(null, $container->getParameter('troopers_alertify.default.layout'));
-        $this->assertEquals('alertify', $container->getParameter('troopers_alertify.default.translationdomain'));
+        $this->assertEquals('alertify', $container->getParameter('troopers_alertify.default.translationDomain'));
     }
 }

--- a/Tests/Handler/AlertifySessionHandlerTest.php
+++ b/Tests/Handler/AlertifySessionHandlerTest.php
@@ -8,11 +8,12 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Troopers\AlertifyBundle\DependencyInjection\TroopersAlertifyExtension;
 use Troopers\AlertifyBundle\Handler\AlertifySessionHandler;
 use Troopers\AlertifyBundle\Helper\AlertifyHelper;
+use Twig\Environment;
 
 class AlertifySessionHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $twigEnvironment;
     /**
@@ -51,7 +52,7 @@ class AlertifySessionHandlerTest extends \PHPUnit\Framework\TestCase
 
     protected function getTwigEnvironmentMock()
     {
-        $twigEnvironment = $this->getMockBuilder('Twig_Environment')
+        $twigEnvironment = $this->getMockBuilder(Environment::class)
             ->disableOriginalConstructor()
             ->setMethods(['render'])
             ->getMock();

--- a/Twig/Extension/AlertifyExtension.php
+++ b/Twig/Extension/AlertifyExtension.php
@@ -4,11 +4,11 @@ namespace Troopers\AlertifyBundle\Twig\Extension;
 
 use Symfony\Component\HttpFoundation\Session\Session;
 use Troopers\AlertifyBundle\Handler\AlertifySessionHandler;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-/**
- * AlertifyExtension.
- */
-class AlertifyExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
+class AlertifyExtension extends AbstractExtension
 {
     /**
      * @var AlertifySessionHandler
@@ -28,14 +28,6 @@ class AlertifyExtension extends \Twig_Extension implements \Twig_Extension_InitR
     /**
      * {@inheritdoc}
      */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'alertify';
@@ -47,19 +39,19 @@ class AlertifyExtension extends \Twig_Extension implements \Twig_Extension_InitR
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('alertify', [$this, 'alertifyFilter'], ['needs_environment' => true, 'is_safe' => ['html']]),
+            new TwigFilter('alertify', [$this, 'alertifyFilter'], ['needs_environment' => true, 'is_safe' => ['html']]),
         ];
     }
 
     /**
      * Alertify filter.
      *
-     * @param \Twig_Environment $environment
-     * @param Session           $session
+     * @param Environment $environment
+     * @param Session     $session
      *
      * @return string
      */
-    public function alertifyFilter($environment, Session $session)
+    public function alertifyFilter(Environment $environment, Session $session)
     {
         return $this->alertifySessionHandler->handle($session, $environment);
     }

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     ],
     "require": {
         "friendsofsymfony/jsrouting-bundle": "^1.0 || ^2.0",
-        "symfony/twig-bundle": "^2.0 || ^3.0 || ^4.0",
-        "symfony/templating": "^2.0 || ^3.0 || ^4.0"
+        "symfony/twig-bundle": "^2.0 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/templating": "^2.0 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "symfony/class-loader": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,15 @@
     ],
     "require": {
         "friendsofsymfony/jsrouting-bundle": "^1.0 || ^2.0",
-        "symfony/twig-bundle": "^2.0 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/templating": "^2.0 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/twig-bundle": "^3.4 || ^4.0 || ^5.0",
+        "symfony/templating": "^3.4 || ^4.0 || ^5.0",
+        "sensio/framework-extra-bundle": "^3.4 || ^4.0 || ^5.0",
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "symfony/class-loader": "~2.1",
-        "phpunit/phpunit": "~5.7"
+        "symfony/phpunit-bridge": "^4.1",
+        "symfony/browser-kit": "^3.4 || ^4.0 || ^5.0",
+        "doctrine/annotations": "^1.4"
     },
     "suggest": {
         "troopers/assetic-injector-bundle": "For Inject libraries in your views easily"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit colors="true" bootstrap="vendor/autoload.php">
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
     <testsuites>
         <testsuite name="TroopersAlertifyBundle Test Suite">
             <directory suffix="Test.php">./Tests/</directory>


### PR DESCRIPTION
Allow Symfony 5 and fix the following:

- As the tests where only running on PHP 7.0, only Symfony 3.4 was tested
- The TreeBuilder was not compatible with SF 4.2
- Parameters should be case sensitive